### PR TITLE
[Ref] 에러 응답 포맷 통일

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import { authRouter } from './routes/auth.router.js';
 import communityRoutes from './routes/community.router.js';
 import { s3Router } from './routes/s3.router.js';
 import { userRouter } from './routes/user.router.js';
+import { HttpException } from './utils/http-exception.js';
 import logger from './utils/logger.js';
 import { limiter } from './utils/rate-limit.js';
 
@@ -45,6 +46,11 @@ app.get('/api/notifications/sse', (req: Request, res: Response) => {
   });
 });
 // ----------------------------------------------------------
+
+app.use((req, res, next) => {
+  // "경로를 찾을 수 없습니다"라는 404 에러를 강제로 발생시켜서 errorMiddleware로 넘김
+  next(HttpException.notFound());
+});
 
 app.use(errorMiddleware);
 

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -36,3 +36,12 @@ export const MESSAGE = {
   tooManyRequests: '요청이 너무 많습니다. 잠시 후 시도해주세요',
   serverError: '문제가 발생했습니다. 나중에 다시 시도하세요',
 };
+
+export const ERROR_NAME = {
+  BAD_REQUEST: 'Bad Request',
+  UNAUTHORIZED: 'Unauthorized',
+  FORBIDDEN: 'Forbidden',
+  NOT_FOUND: 'Not Found',
+  CONFLICT: 'Conflict',
+  INTERNAL_SERVER_ERROR: 'Internal Server Error',
+};

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,27 +1,71 @@
 import type { NextFunction, Request, Response } from 'express';
 
-import { MESSAGE } from '../constants/constant.js';
-import type { HttpException } from '../utils/http-exception.js';
+import { ERROR_NAME, MESSAGE, STATUS_CODE } from '../constants/constant.js';
+import { HttpException } from '../utils/http-exception.js';
 import logger from '../utils/logger.js';
 
-export const errorMiddleware = (err: HttpException, req: Request, res: Response, _next: NextFunction) => {
+interface ErrorWithStatus {
+  status?: number;
+  message?: string;
+}
+
+export const errorMiddleware = (err: Error | HttpException, req: Request, res: Response, _next: NextFunction) => {
+  // 기본값 설정 (500 서버 에러)
+  let status = STATUS_CODE.INTERNAL_SERVER_ERROR;
+  let message = MESSAGE.serverError;
+
+  if (err instanceof HttpException) {
+    status = err.status;
+    message = err.message;
+  } else {
+    const error = err as ErrorWithStatus;
+    if (error.status) {
+      status = error.status;
+      // 메시지가 있으면 쓰고, 없으면 기존 서버 에러 메시지 유지
+      message = error.message || message;
+    }
+  }
+
+  // 에러 이름 결정 (Swagger용)
+  const errorName = getErrorName(status);
+
+  // 로깅
   logger.error({
     timestamp: new Date().toISOString(),
     url: req.originalUrl,
     method: req.method,
-    status: err.status || 500,
-    message: err.message,
+    status: status,
+    message: message, // 사용자에게 나가는 메시지
     body: req.body, // 요청 본문
-    query: req.query, // 쿼리
-    params: req.params, // URL params
-    stack: err.stack || null, // 스택 트레이스
+    query: req.query, // 쿼리 스트링
+    params: req.params, // URL 파라미터
+    stack: err.stack || null, // 디버깅용 스택 트레이스
   });
 
-  const status = err.status || 500;
-  const message = status === 500 ? MESSAGE.serverError : err.message;
-
+  // 응답 전송 (Swagger 규격 준수)
   res.status(status).json({
     message: message,
-    path: req.originalUrl,
+    statusCode: status,
+    error: errorName,
   });
 };
+
+// [보조 함수]
+function getErrorName(status: number): string {
+  switch (status) {
+    case STATUS_CODE.BAD_REQUEST:
+      return ERROR_NAME.BAD_REQUEST;
+    case STATUS_CODE.UNAUTHORIZED:
+      return ERROR_NAME.UNAUTHORIZED;
+    case STATUS_CODE.FORBIDDEN:
+      return ERROR_NAME.FORBIDDEN;
+    case STATUS_CODE.NOT_FOUND:
+      return ERROR_NAME.NOT_FOUND;
+    case STATUS_CODE.CONFLICT:
+      return ERROR_NAME.CONFLICT;
+    case STATUS_CODE.INTERNAL_SERVER_ERROR:
+      return ERROR_NAME.INTERNAL_SERVER_ERROR;
+    default:
+      return 'Error';
+  }
+}


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
Swagger 명세 및 프론트엔드 연동 규격에 맞춰 글로벌 에러 핸들러의 응답 포맷을 표준화했습니다. 또한, 존재하지 않는 API 경로로 요청 시 HTML이 아닌 JSON 에러 응답이 반환되도록 404 처리 로직을 추가했습니다.

## 📚 관련 이슈 (Related Issues)
closes #38 

## ✨ 핵심 변경 사항 (Core Changes)
1. 에러 응답 포맷 통일 (src/middlewares/error.middleware.ts)
기존: { message, path } 등 불규칙한 포맷
변경: { message, statusCode, error } 로 통일 (Swagger 규격 준수)
any 타입을 제거하고 인터페이스(ErrorWithStatus)를 정의하여 타입 안전성 확보
ERROR_NAME 상수를 활용하여 상태 코드에 따른 에러 이름(예: 'Conflict', 'Bad Request') 자동 매핑

2. 404 Not Found 처리 추가 (src/app.ts)
기존에는 정의되지 않은 라우트로 요청 시 Express 기본 HTML 페이지가 반환되는 문제가 있었음.
라우터 설정 하단에 404 에러를 강제로 발생시키는 미들웨어를 추가하여, 없는 주소 요청 시에도 글로벌 에러 핸들러를 타도록 수정.

3. 상수 추가 (src/constants/constant.ts)
HTTP 상태 코드에 대응하는 에러 이름(ERROR_NAME) 상수 객체 추가.

## 📸 스크린샷 또는 비디오 (Screenshots or Videos)
Before (기존)

```
JSON

{
  "message": "이미 존재하는 유저입니다",
  "path": "/api/users"
}
(404 발생 시 HTML 페이지 리턴됨)

After (변경 후 - Swagger 규격 일치)
```

After
```
JSON

{
  "message": "이미 존재하는 유저입니다",
  "statusCode": 409,
  "error": "Conflict"
}
```


## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
src/middlewares/error.middleware.ts: getErrorName 함수를 통해 상태 코드별로 에러 이름을 매핑하는 로직이 적절한지 확인 부탁드립니다.

src/app.ts: 404 처리 미들웨어의 위치(라우터 아래, 에러 핸들러 위)가 적절한지 확인 부탁드립니다.

## ✅ 체크리스트 (Checklist)
[x] 빌드 및 테스트를 통과했습니다.

[x] 코드 스타일 가이드라인을 준수했습니다.

[x] 리뷰어에게 필요한 모든 정보를 제공했습니다.