### PR TITLE
[Fix] s3-upload 예외 처리

### DIFF
--- a/src/middlewares/upload.middleware.ts
+++ b/src/middlewares/upload.middleware.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { config } from '../config/config.js';
 import { HttpException } from '../utils/http-exception.js';
+import logger from '../utils/logger.js';
 
 // 허용할 파일 확장자 및 MIME 타입 정의
 const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
@@ -86,7 +87,8 @@ export const uploadImage = (req: Request, res: Response, next: NextFunction) => 
           return next(HttpException.badRequest('하나의 파일만 업로드할 수 있습니다.'));
         default:
           // 기타 Multer 에러
-          return next(HttpException.badRequest(`파일 업로드 중 오류가 발생했습니다: ${err.message}`));
+          logger.error(err, 'Multer 파일 업로드 중 예기치 않은 오류 발생:');
+          return next(HttpException.badRequest('파일 업로드 중 오류가 발생했습니다.'));
       }
     } else if (err) {
       // fileFilter에서 발생한 HttpException 또는 기타 에러

--- a/src/middlewares/upload.middleware.ts
+++ b/src/middlewares/upload.middleware.ts
@@ -1,6 +1,6 @@
 import { S3Client } from '@aws-sdk/client-s3';
-import type { Request } from 'express';
-import multer from 'multer';
+import type { NextFunction, Request, Response } from 'express';
+import multer, { MulterError } from 'multer';
 import multerS3 from 'multer-s3';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -8,11 +8,19 @@ import { v4 as uuidv4 } from 'uuid';
 import { config } from '../config/config.js';
 import { HttpException } from '../utils/http-exception.js';
 
+// 허용할 파일 확장자 및 MIME 타입 정의
+const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+const MIME_TYPE_MAP: Record<string, string[]> = {
+  'image/jpeg': ['jpg', 'jpeg'],
+  'image/png': ['png'],
+  'image/webp': ['webp'],
+};
+
 // S3 클라이언트 생성
 const s3 = new S3Client({
   credentials: {
-    accessKeyId: config.aws.accessKeyId!,
-    secretAccessKey: config.aws.secretAccessKey!,
+    accessKeyId: config.aws.accessKeyId,
+    secretAccessKey: config.aws.secretAccessKey,
   },
   region: config.aws.region,
 });
@@ -26,7 +34,8 @@ const getFormattedDate = () => {
   return `${year}${month}${day}`;
 };
 
-export const uploadMiddleware = multer({
+// Multer 설정
+const upload = multer({
   storage: multerS3({
     s3: s3,
     bucket: config.aws.bucketName!,
@@ -35,20 +44,56 @@ export const uploadMiddleware = multer({
       const date = getFormattedDate();
       const uuid = uuidv4();
       const originalName = file.originalname;
-      const ext = path.extname(originalName); // 확장자
-      const baseName = path.basename(originalName, ext); // 확장자를 제외한 파일 이름
+      const ext = path.extname(originalName);
+      const baseName = path.basename(originalName, ext);
       cb(null, `uploads/${date}/${uuid}_${baseName}${ext}`);
     },
   }),
   fileFilter: (req: Request, file, cb) => {
-    // 이미지 파일만 허용
-    if (file.mimetype.startsWith('image/')) {
-      cb(null, true);
-    } else {
-      cb(HttpException.badRequest('이미지 파일만 업로드 가능합니다.'));
+    const ext = path.extname(file.originalname).toLowerCase().substring(1);
+
+    // 1. 허용된 확장자인지 검증
+    if (!ALLOWED_EXTENSIONS.includes(ext)) {
+      return cb(HttpException.badRequest(`허용되지 않는 확장자입니다: ${ext}`));
     }
+
+    // 2. 허용된 MIME 타입인지 검증
+    const allowedMimeTypes = Object.keys(MIME_TYPE_MAP);
+    if (!allowedMimeTypes.includes(file.mimetype)) {
+      return cb(HttpException.badRequest('허용되지 않는 파일 유형입니다.'));
+    }
+
+    // 3. 확장자와 MIME 타입이 일치하는지 검증
+    if (!MIME_TYPE_MAP[file.mimetype]?.includes(ext)) {
+      return cb(HttpException.badRequest('파일 확장자와 실제 파일 유형이 일치하지 않습니다.'));
+    }
+
+    cb(null, true);
   },
   limits: {
     fileSize: 5 * 1024 * 1024, // 5MB 제한
   },
 });
+
+ // Multer 에러를 핸들링하는 커스텀 미들웨어
+export const uploadImage = (req: Request, res: Response, next: NextFunction) => {
+  upload.single('image')(req, res, (err) => {
+    if (err instanceof MulterError) {
+      switch (err.code) {
+        case 'LIMIT_FILE_SIZE':
+          return next(HttpException.badRequest('파일 크기는 5MB를 초과할 수 없습니다.'));
+        case 'LIMIT_UNEXPECTED_FILE':
+          return next(HttpException.badRequest('하나의 파일만 업로드할 수 있습니다.'));
+        default:
+          // 기타 Multer 에러
+          return next(HttpException.badRequest(`파일 업로드 중 오류가 발생했습니다: ${err.message}`));
+      }
+    } else if (err) {
+      // fileFilter에서 발생한 HttpException 또는 기타 에러
+      return next(err);
+    }
+
+    // 에러가 없으면 다음 미들웨어로 진행
+    next();
+  });
+};

--- a/src/middlewares/upload.middleware.ts
+++ b/src/middlewares/upload.middleware.ts
@@ -75,7 +75,7 @@ const upload = multer({
   },
 });
 
- // Multer 에러를 핸들링하는 커스텀 미들웨어
+// Multer 에러를 핸들링하는 커스텀 미들웨어
 export const uploadImage = (req: Request, res: Response, next: NextFunction) => {
   upload.single('image')(req, res, (err) => {
     if (err instanceof MulterError) {

--- a/src/routes/s3.router.ts
+++ b/src/routes/s3.router.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 
 import { s3Controller } from '../controllers/s3.controller.js';
-import { uploadMiddleware } from '../middlewares/upload.middleware.js';
+import { uploadImage } from '../middlewares/upload.middleware.js';
 
 export const s3Router = express.Router();
 
 // POST /api/s3/upload
-s3Router.post('/upload', uploadMiddleware.single('image'), s3Controller.uploadImage);
+s3Router.post('/upload', uploadImage, s3Controller.uploadImage);

--- a/test-https/s3.http
+++ b/test-https/s3.http
@@ -1,14 +1,52 @@
-### 환경 변수
+### test-https 상위 폴더에 test.jpg(정상 파일)와 fake.jpg(텍스트 파일)이 존재해야 합니다 !!
+### 환경 변수 설정
 @host = http://localhost:3001
+@boundary = ----WebKitFormBoundary7MA4YWxkTrZu0gW
 
-### 1. 이미지 업로드 테스트
+# -------------------------------------------------------
+# 1. [성공 케이스] 정상적인 JPG 이미지 업로드
+# -------------------------------------------------------
+# 예상 결과: 200 OK (업로드 성공)
 POST {{host}}/api/s3/upload
-Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Type: multipart/form-data; boundary={{boundary}}
 
-------WebKitFormBoundary7MA4YWxkTrZu0gW
+--{{boundary}}
 Content-Disposition: form-data; name="image"; filename="test.jpg"
 Content-Type: image/jpeg
 
-// 테스트 할 이미지를 프로젝트 폴더에 생성하고 테스트 진행
-< ./../test.jpg
-------WebKitFormBoundary7MA4YWxkTrZu0gW--
+< ./test.jpg
+--{{boundary}}--
+
+###
+
+# -------------------------------------------------------
+# 2. [실패 케이스] 가짜 이미지 파일 (MIME Type 불일치)
+# -------------------------------------------------------
+# 시나리오: 확장자는 .jpg지만, 실제 타입(Content-Type)은 text/plain인 경우
+# 예상 결과: 400 Bad Request ("파일 확장자와 실제 파일 유형이 일치하지 않습니다.")
+POST {{host}}/api/s3/upload
+Content-Type: multipart/form-data; boundary={{boundary}}
+
+--{{boundary}}
+Content-Disposition: form-data; name="image"; filename="fake.jpg"
+Content-Type: text/plain
+
+< ./fake.jpg
+--{{boundary}}--
+
+###
+
+# -------------------------------------------------------
+# 3. [실패 케이스] 허용되지 않은 확장자 (.txt)
+# -------------------------------------------------------
+# 시나리오: 그냥 대놓고 .txt 파일을 올리는 경우
+# 예상 결과: 400 Bad Request ("허용되지 않는 확장자입니다: txt")
+POST {{host}}/api/s3/upload
+Content-Type: multipart/form-data; boundary={{boundary}}
+
+--{{boundary}}
+Content-Disposition: form-data; name="image"; filename="memo.txt"
+Content-Type: text/plain
+
+< ./fake.jpg
+--{{boundary}}--


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
기존 S3 이미지 업로드 미들웨어의 보안 취약점을 보완하고, 에러 핸들링을 개선했습니다. Multer 레벨에서 발생하는 에러를 적절한 HTTP 상태 코드(400)로 변환하고, 파일 확장자와 MIME 타입을 이중으로 검증하는 로직을 추가했습니다.

## 📚 관련 이슈 (Related Issues)
Closes #91
PR #87 

## ✨ 핵심 변경 사항 (Core Changes)
MulterError 예외처리 강화
=> 기존에는 용량 초과 시 500 에러가 발생했으나, 커스텀 미들웨어로 래핑하여 400 Bad Request와 명확한 에러 메시지를 반환하도록 수정했습니다.

파일 개수 초과등의 에러도 핸들링했습니다

이중 검증: 파일의 확장자와 MIME Type이 일치하는지(MIME_TYPE_MAP 활용) 확인하여, 확장자 위변조 파일 업로드를 방지했습니다.

미들웨어 함수명 변경(uploadMiddleware -> uploadImage)에 따라 s3.router.ts의 import 구문을 수정했습니다.

## 📸 스크린샷 또는 비디오 (Screenshots or Videos)
깜빡하고 스크린 샷을 찍지 못했습니다... ㅎㅎ


## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
src/middlewares/upload.middleware.ts 내부의 fileFilter 로직에서 확장자와 MIME 타입을 매핑하여 검사하는 부분이 보안상 적절한지 확인 부탁드립니다.

MulterError를 HttpException으로 변환하는 로직이 의도대로 잘 구현되었는지 봐주시면 감사하겠습니다.

## ✅ 체크리스트 (Checklist)
[x] 빌드 및 테스트를 통과했습니다.

[x] 코드 스타일 가이드라인을 준수했습니다.

[x] 리뷰어에게 필요한 모든 정보를 제공했습니다.