### PR TITLE
[Feat] soft delete, 트랜잭션

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
-          cache: 'npm'
+
+      - name: node_modules 캐시
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: 모듈 설치
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Prettier 체크

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+          cache: 'npm'
 
-      - name: 노드 모듈 캐시
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: 'node_modules'
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
       - name: 모듈 설치
-        # 이전의 cache가 없다면 의존성을 설치
-        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Prettier 체크

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "multer-s3": "^3.0.1",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.2",
-        "prisma-extension-soft-delete": "^2.0.1",
         "uuid": "^13.0.0",
         "zod": "^4.1.13"
       },
@@ -258,7 +257,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.947.0.tgz",
       "integrity": "sha512-ICgnI8D3ccIX9alsLksPFY2bX5CAIbyB+q19sXJgPhzCJ5kWeQ6LQ5xBmRVT5kccmsVGbbJdhnLXHyiN5LZsWg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1146,10 +1144,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "license": "MIT"
-    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "license": "MIT"
@@ -1158,7 +1152,6 @@
       "version": "6.19.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2026,7 +2019,6 @@
       "version": "5.0.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -3603,7 +3595,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4680,10 +4671,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
@@ -5276,7 +5263,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.0",
         "@prisma/engines": "6.19.0"
@@ -5294,27 +5280,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/prisma-extension-nested-operations": {
-      "version": "1.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@open-draft/deferred-promise": "^2.1.0",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "@prisma/client": "*"
-      }
-    },
-    "node_modules/prisma-extension-soft-delete": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "prisma-extension-nested-operations": "^1.0.1"
-      },
-      "peerDependencies": {
-        "@prisma/client": "*"
       }
     },
     "node_modules/process-warning": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "multer-s3": "^3.0.1",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.2",
-    "prisma-extension-soft-delete": "^2.0.1",
     "uuid": "^13.0.0",
     "zod": "^4.1.13"
   },

--- a/prisma/migrations/20251202041803_init/migration.sql
+++ b/prisma/migrations/20251202041803_init/migration.sql
@@ -324,6 +324,9 @@ CREATE INDEX "RefreshToken_deletedAt_idx" ON "RefreshToken"("deletedAt");
 CREATE INDEX "RefreshToken_issuedAt_idx" ON "RefreshToken"("issuedAt");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_deviceId_deletedAt_key" ON "RefreshToken"("deviceId", "deletedAt");
+
+-- CreateIndex
 CREATE INDEX "Device_userId_lastUsedAt_idx" ON "Device"("userId", "lastUsedAt");
 
 -- CreateIndex

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model RefreshToken {
 
   @@index([deletedAt])
   @@index([issuedAt])
+  @@unique([deviceId, deletedAt])
 }
 
 model Device {

--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -14,7 +14,7 @@ export const STATUS_CODE = {
 
 export const MESSAGE = {
   userAuthenticated: '사용자가 성공적으로 인증되었습니다',
-  emailAready: '이미 존재하는 유저입니다',
+  emailAlready: '이미 존재하는 유저입니다',
   logoutSuccess: '성공적으로 로그아웃되었습니다',
   userDeleted: '회원탈퇴를 성공했습니다',
   invalidPassword: '현재 비밀번호가 올바르지 않습니다',

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -5,20 +5,40 @@ import type { HttpException } from '../utils/http-exception.js';
 import logger from '../utils/logger.js';
 
 export const errorMiddleware = (err: HttpException, req: Request, res: Response, _next: NextFunction) => {
-  logger.error({
+  const status = err.status || 500;
+  const message = status === 500 ? MESSAGE.serverError : err.message;
+
+  // 프로젝트 루트 경로
+  const projectRoot = process.cwd();
+
+  // 스택 트레이스를 배열로 변환하고 절대 경로를 상대 경로로 변환
+  const stackLines = err.stack
+    ? err.stack.split('\n').map((line) => {
+        // 절대 경로를 프로젝트 루트 기준 상대 경로로 변환
+        return line.trim().replace(new RegExp(projectRoot, 'g'), '.');
+      })
+    : [];
+
+  const logData = {
     timestamp: new Date().toISOString(),
     url: req.originalUrl,
     method: req.method,
-    status: err.status || 500,
+    status,
     message: err.message,
-    body: req.body, // 요청 본문
-    query: req.query, // 쿼리
-    params: req.params, // URL params
-    stack: err.stack || null, // 스택 트레이스
-  });
+    request: {
+      body: req.body,
+      query: req.query,
+      params: req.params,
+    },
+    stack: stackLines,
+  };
 
-  const status = err.status || 500;
-  const message = status === 500 ? MESSAGE.serverError : err.message;
+  // 5xx 에러(서버 에러)는 error 레벨, 4xx 에러(클라이언트 에러)는 warn 레벨로 로깅
+  if (status >= 500) {
+    logger.error(logData, `서버 에러 [${status}]`);
+  } else {
+    logger.warn(logData, `클라이언트 요청 에러 [${status}]`);
+  }
 
   res.status(status).json({
     message: message,

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -4,18 +4,18 @@ import type {
   DeleteRefreshTokenData,
   loginUpdateData,
 } from '../types/auth.type.js';
-import prisma, { type ExtendedDeleteArgs } from '../utils/prisma.js';
+import prisma, { type ExtendedDeleteArgs, type ExtendedTransactionClient } from '../utils/prisma.js';
 
 class AuthRepository {
-  login = async (data: loginUpdateData) => {
-    await prisma.user.update({
-      where: { id: data.userId },
+  login = async (input: loginUpdateData, tx: ExtendedTransactionClient) => {
+    await tx.user.update({
+      where: { id: input.userId },
       data: {
         lastLoginAt: new Date(),
       },
     });
-    await prisma.device.update({
-      where: { id: data.deviceId },
+    await tx.device.update({
+      where: { id: input.deviceId },
       data: {
         lastUsedAt: new Date(),
       },
@@ -36,18 +36,18 @@ class AuthRepository {
     });
   };
 
-  findDeviceByUserAgent = async (data: BaseDevice) => {
-    return await prisma.device.findFirst({
+  findDeviceByUserAgent = async (input: BaseDevice, tx: ExtendedTransactionClient) => {
+    return await tx.device.findFirst({
       where: {
-        userId: data.userId,
-        userAgent: data.userAgent ?? 'unknown', // TODO: unknown 나중에 한 번 더 고민해보기
+        userId: input.userId,
+        userAgent: input.userAgent ?? 'unknown', // TODO: unknown 나중에 한 번 더 고민해보기
       },
       include: { refreshTokens: true },
     });
   };
 
-  findDeviceCount = async (userId: string) => {
-    return await prisma.device.count({
+  findDeviceCount = async (userId: string, tx: ExtendedTransactionClient) => {
+    return await tx.device.count({
       where: { userId },
     });
   };
@@ -66,31 +66,31 @@ class AuthRepository {
     });
   };
 
-  deleteDevice = async (deviceId: string) => {
-    return await prisma.device.delete({
+  deleteDevice = async (deviceId: string, tx: ExtendedTransactionClient) => {
+    return await tx.device.delete({
       where: { id: deviceId },
     });
   };
 
-  createDevice = async (data: BaseDevice) => {
-    return await prisma.device.create({
+  createDevice = async (input: BaseDevice, tx: ExtendedTransactionClient) => {
+    return await tx.device.create({
       data: {
-        user: { connect: { id: data.userId } },
-        userAgent: data.userAgent ?? 'unknown',
-        ip: data.ip,
+        user: { connect: { id: input.userId } },
+        userAgent: input.userAgent ?? 'unknown',
+        ip: input.ip,
         lastUsedAt: new Date(),
       },
     });
   };
 
-  createRefreshToken = async (inputData: CreateRefreshTokenInput) => {
+  createRefreshToken = async (input: CreateRefreshTokenInput, tx: ExtendedTransactionClient) => {
     // 새 토큰 생성
-    return await prisma.refreshToken.create({
+    return await tx.refreshToken.create({
       data: {
-        jti: inputData.jti,
-        device: { connect: { id: inputData.deviceId } },
-        issuedAt: inputData.issuedAt,
-        expiresAt: inputData.expiresAt,
+        jti: input.jti,
+        device: { connect: { id: input.deviceId } },
+        issuedAt: input.issuedAt,
+        expiresAt: input.expiresAt,
         lastUsedAt: new Date(),
       },
     });
@@ -124,6 +124,13 @@ class AuthRepository {
 
   deleteRefreshToken = async (inputData: DeleteRefreshTokenData) => {
     return await prisma.refreshToken.delete({
+      where: { jti: inputData.jti },
+      reason: inputData.reason,
+    } as ExtendedDeleteArgs<Parameters<typeof prisma.refreshToken.delete>[0]>);
+  };
+
+  deleteRefreshTokenWithTx = async (inputData: DeleteRefreshTokenData, tx: ExtendedTransactionClient) => {
+    return await tx.refreshToken.delete({
       where: { jti: inputData.jti },
       reason: inputData.reason,
     } as ExtendedDeleteArgs<Parameters<typeof prisma.refreshToken.delete>[0]>);

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,11 +1,10 @@
-
 import type {
   BaseDevice,
   CreateRefreshTokenInput,
   DeleteRefreshTokenData,
-  loginUpdateData
+  loginUpdateData,
 } from '../types/auth.type.js';
-import prisma from '../utils/prisma.js';
+import prisma, { type ExtendedDeleteArgs } from '../utils/prisma.js';
 
 class AuthRepository {
   login = async (data: loginUpdateData) => {
@@ -43,7 +42,7 @@ class AuthRepository {
         userId: data.userId,
         userAgent: data.userAgent ?? 'unknown', // TODO: unknown 나중에 한 번 더 고민해보기
       },
-      include: { refreshTokens: true }
+      include: { refreshTokens: true },
     });
   };
 
@@ -125,10 +124,10 @@ class AuthRepository {
 
   deleteRefreshToken = async (inputData: DeleteRefreshTokenData) => {
     return await prisma.refreshToken.delete({
-      where: { jti: inputData.jti, },
+      where: { jti: inputData.jti },
       reason: inputData.reason,
-    })
-  }
+    } as ExtendedDeleteArgs<Parameters<typeof prisma.refreshToken.delete>[0]>);
+  };
 }
 
 export const authRepository = new AuthRepository();

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -135,6 +135,23 @@ class AuthRepository {
       reason: inputData.reason,
     } as ExtendedDeleteArgs<Parameters<typeof prisma.refreshToken.delete>[0]>);
   };
+
+  findUserDeviceIds = async (userId: string, tx: ExtendedTransactionClient) => {
+    const devices = await tx.device.findMany({
+      where: { userId },
+      select: { id: true },
+    });
+    return devices.map((device) => device.id);
+  };
+
+  deleteRefreshTokensByDeviceIds = async (deviceIds: string[], reason: string, tx: ExtendedTransactionClient) => {
+    return await tx.refreshToken.deleteMany({
+      where: {
+        deviceId: { in: deviceIds },
+      },
+      reason,
+    } as ExtendedDeleteArgs<Parameters<typeof tx.refreshToken.deleteMany>[0]>);
+  };
 }
 
 export const authRepository = new AuthRepository();

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,9 +1,9 @@
+
 import type {
   BaseDevice,
   CreateRefreshTokenInput,
   DeleteRefreshTokenData,
-  DeleteRefreshTokenDataByDeviceId,
-  loginUpdateData,
+  loginUpdateData
 } from '../types/auth.type.js';
 import prisma from '../utils/prisma.js';
 
@@ -43,6 +43,7 @@ class AuthRepository {
         userId: data.userId,
         userAgent: data.userAgent ?? 'unknown', // TODO: unknown 나중에 한 번 더 고민해보기
       },
+      include: { refreshTokens: true }
     });
   };
 
@@ -123,27 +124,11 @@ class AuthRepository {
   };
 
   deleteRefreshToken = async (inputData: DeleteRefreshTokenData) => {
-    return await prisma.refreshToken.deleteWithReason({
-      where: {
-        jti: inputData.jti,
-      },
+    return await prisma.refreshToken.delete({
+      where: { jti: inputData.jti, },
       reason: inputData.reason,
-    });
-  };
-
-  // TODO: 프리즈마 확장으로 사용하고 싶은데 확장을 2개로 하면 에러 발생
-  // deleteWithReason에 where을 jti 또는 deviceId로 설정 가능한지 알아보기
-  deleteRefreshTokenByDeviceId = async (inputData: DeleteRefreshTokenDataByDeviceId) => {
-    return await prisma.refreshToken.updateMany({
-      where: {
-        deviceId: inputData.deviceId,
-      },
-      data: {
-        reason: inputData.reason,
-        deletedAt: new Date(),
-      },
-    });
-  };
+    })
+  }
 }
 
 export const authRepository = new AuthRepository();

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import type { createUser } from '../dtos/user.dto.js';
 import type { UpdateUser } from '../types/user.type.js';
-import prisma from '../utils/prisma.js';
+import prisma, { type ExtendedTransactionClient } from '../utils/prisma.js';
 
 class UserRepository {
   getById = async (id: string) => {
@@ -45,6 +45,12 @@ class UserRepository {
 
   delete = async (id: string) => {
     return await prisma.user.delete({
+      where: { id },
+    });
+  };
+
+  deleteWithTx = async (id: string, tx: ExtendedTransactionClient) => {
+    return await tx.user.delete({
       where: { id },
     });
   };

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -98,14 +98,21 @@ const verifyUser = async (data: BaseLogin) => {
 // 디바이스 찾기 또는 생성
 const findOrCreateDevice = async (data: BaseDevice) => {
   const { userId, userAgent, ip } = data;
-  let device = await authRepository.findDeviceByUserAgent({ userId, userAgent, ip });
+  const device = await authRepository.findDeviceByUserAgent({ userId, userAgent, ip });
+
   if (!device) {
     await deviceLimit(userId);
-    device = await authRepository.createDevice({ userId, userAgent, ip });
-    return device;
+    const newDevice = await authRepository.createDevice({ userId, userAgent, ip });
+    return newDevice;
   }
 
-  await authRepository.deleteRefreshTokenByDeviceId({ deviceId: device.id, reason: DeletedTokenReason.REPLACED });
+  const activeToken = device.refreshTokens[0];
+  if (activeToken?.jti) {
+    await authRepository.deleteRefreshToken({
+      jti: activeToken.jti,
+      reason: DeletedTokenReason.REPLACED,
+    });
+  }
   return device;
 };
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -7,24 +7,27 @@ import { config } from '../config/config.js';
 import { authRepository } from '../repositories/auth.repository.js';
 import type { BaseDevice, BaseLogin, LoginData, loginUpdateData } from '../types/auth.type.js';
 import { HttpException } from '../utils/http-exception.js';
+import prisma, { type ExtendedTransactionClient } from '../utils/prisma.js';
 
 class AuthService {
-  login = async (inputData: LoginData) => {
-    const { email, password, userAgent, ip } = inputData;
+  login = async (input: LoginData) => {
+    const user = await verifyUser({ email: input.email, password: input.password }); // 유저 찾기, 비밀번호 비교
 
-    const user = await verifyUser({ email, password }); // 유저 찾기, 비밀번호 비교
-    const device = await findOrCreateDevice({ userId: user.id, userAgent, ip }); // 기기 찾기 또는 만들기
-    const tokens = await generateTokens({ userId: user.id, deviceId: device.id }); // 엑세스 토큰 만들기
+    const tokens = await prisma.$transaction(async (tx) => {
+      const device = await findOrCreateDevice({ userId: user.id, userAgent: input.userAgent, ip: input.ip }, tx); // 기기 찾기 또는 만들기
+      const tokens = await generateTokens({ userId: user.id, deviceId: device.id }); // 엑세스 토큰 만들기
 
-    await authRepository.createRefreshToken({
-      jti: tokens.jti,
-      deviceId: device.id,
-      issuedAt: tokens.refreshTokenIssuedAt,
-      expiresAt: tokens.refreshTokenExpiresAt,
-    });
-    await authRepository.login({
-      deviceId: device.id,
-      userId: user.id,
+      await authRepository.createRefreshToken(
+        {
+          jti: tokens.jti,
+          deviceId: device.id,
+          issuedAt: tokens.refreshTokenIssuedAt,
+          expiresAt: tokens.refreshTokenExpiresAt,
+        },
+        tx,
+      );
+      await authRepository.login({ deviceId: device.id, userId: user.id }, tx);
+      return tokens;
     });
 
     return {
@@ -96,41 +99,47 @@ const verifyUser = async (data: BaseLogin) => {
 };
 
 // 디바이스 찾기 또는 생성
-const findOrCreateDevice = async (data: BaseDevice) => {
-  const { userId, userAgent, ip } = data;
-  const device = await authRepository.findDeviceByUserAgent({ userId, userAgent, ip });
+const findOrCreateDevice = async (input: BaseDevice, tx: ExtendedTransactionClient) => {
+  const { userId, userAgent, ip } = input;
+  const device = await authRepository.findDeviceByUserAgent({ userId, userAgent, ip }, tx);
 
   if (!device) {
-    await deviceLimit(userId);
-    const newDevice = await authRepository.createDevice({ userId, userAgent, ip });
+    await deviceLimit(userId, tx);
+    const newDevice = await authRepository.createDevice({ userId, userAgent, ip }, tx);
     return newDevice;
   }
 
   const activeToken = device.refreshTokens[0];
   if (activeToken?.jti) {
-    await authRepository.deleteRefreshToken({
-      jti: activeToken.jti,
-      reason: DeletedTokenReason.REPLACED,
-    });
+    await authRepository.deleteRefreshTokenWithTx(
+      {
+        jti: activeToken.jti,
+        reason: DeletedTokenReason.REPLACED,
+      },
+      tx,
+    );
   }
   return device;
 };
 
-const deviceLimit = async (userId: string) => {
-  const count = await authRepository.findDeviceCount(userId);
+const deviceLimit = async (userId: string, tx: ExtendedTransactionClient) => {
+  const count = await authRepository.findDeviceCount(userId, tx);
   if (count < config.auth.maxDevice) return;
 
   const oldestDevice = await authRepository.findLastUsedDevice(userId);
   if (!oldestDevice) throw HttpException.notFound();
 
-  await authRepository.deleteDevice(oldestDevice.id);
+  await authRepository.deleteDevice(oldestDevice.id, tx);
 
   const token = oldestDevice.refreshTokens?.[0];
   if (token) {
-    await authRepository.deleteRefreshToken({
-      jti: token.jti,
-      reason: DeletedTokenReason.DEVICE_LIMIT,
-    });
+    await authRepository.deleteRefreshTokenWithTx(
+      {
+        jti: token.jti,
+        reason: DeletedTokenReason.DEVICE_LIMIT,
+      },
+      tx,
+    );
   }
 };
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,6 +1,5 @@
 import { DeletedTokenReason, Prisma } from '@prisma/client';
 import bcrypt from 'bcrypt';
-import jwt from 'jsonwebtoken';
 
 import { config } from '../config/config.js';
 import { MESSAGE } from '../constants/constant.js';
@@ -49,14 +48,12 @@ class UserService {
   };
 
   delete = async (input: deleteUser) => {
-    const decoded = jwt.verify(input.refreshToken, config.auth.refreshTokenSecretKey);
-    if (!decoded || typeof decoded === 'string' || !decoded.jti) throw HttpException.tokenError();
-
-    const jti = decoded.jti;
-
-    // RefreshToken 삭제와 User 삭제 트랜잭션
     return await prisma.$transaction(async (tx) => {
-      await authRepository.deleteRefreshTokenWithTx({ jti, reason: DeletedTokenReason.DELETED_USER }, tx);
+      // 사용자의 모든 디바이스 ID 조회
+      const deviceIds = await authRepository.findUserDeviceIds(input.userId, tx);
+      // 해당 디바이스들의 모든 RefreshToken 삭제
+      await authRepository.deleteRefreshTokensByDeviceIds(deviceIds, DeletedTokenReason.DELETED_USER, tx);
+      // 사용자 삭제
       return await userRepository.deleteWithTx(input.userId, tx);
     });
   };

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -10,6 +10,7 @@ import { userRepository } from '../repositories/user.repository.js';
 import { UserResponse } from '../serializes/user.serialize.js';
 import type { deleteUser, UpdateUserInput } from '../types/user.type.js';
 import { HttpException } from '../utils/http-exception.js';
+import prisma from '../utils/prisma.js';
 
 class UserService {
   getById = async (userId: string) => {
@@ -51,8 +52,13 @@ class UserService {
     const decoded = jwt.verify(input.refreshToken, config.auth.refreshTokenSecretKey);
     if (!decoded || typeof decoded === 'string' || !decoded.jti) throw HttpException.tokenError();
 
-    await authRepository.deleteRefreshToken({ jti: decoded.jti, reason: DeletedTokenReason.DELETED_USER });
-    return await userRepository.delete(input.userId);
+    const jti = decoded.jti;
+
+    // RefreshToken 삭제와 User 삭제 트랜잭션
+    return await prisma.$transaction(async (tx) => {
+      await authRepository.deleteRefreshTokenWithTx({ jti, reason: DeletedTokenReason.DELETED_USER }, tx);
+      return await userRepository.deleteWithTx(input.userId, tx);
+    });
   };
 
   getLikeStores = async (userId: string) => {

--- a/src/utils/http-exception.ts
+++ b/src/utils/http-exception.ts
@@ -52,7 +52,7 @@ export class HttpException extends Error {
   static unavailableEmail() {
     return new HttpException({
       status: STATUS_CODE.CONFLICT,
-      message: MESSAGE.emailAready,
+      message: MESSAGE.emailAlready,
     });
   }
 

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,42 +1,96 @@
-import { DeletedTokenReason, Prisma, PrismaClient } from '@prisma/client';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Prisma, PrismaClient } from '@prisma/client';
+import type { Operation } from '@prisma/client/runtime/binary';
 
-type UpdateDelegate<T> = {
-  update(
-    args: Prisma.Args<T, 'update'>
-  ): Prisma.Result<T, Prisma.Args<T, 'update'>, 'update'>;
-};
+import logger from './logger.js';
 
-export const softDelete = () => {
-  return {
-    async delete<T>(
-      this: T,
-      args: Prisma.Args<T, 'delete'> & { reason?: DeletedTokenReason}
-    ): Promise<Prisma.Result<T, Prisma.Args<T, 'update'>, 'update'>> {
-      const ctx =
-        Prisma.getExtensionContext(this) as unknown as UpdateDelegate<T>;
+export type ExtendedDeleteArgs<T> = T & { reason?: string };
 
-      return ctx.update({
-        where: args.where,
-        data: {
-          deletedAt: new Date(),
-          ...(args.reason ? { reason: args.reason } : {}),
+const SOFT_DELETE_MODELS = new Set([
+  'User',
+  'Device',
+  'RefreshToken',
+  'Store',
+  'Product',
+  'Order',
+  'OrderItem',
+  'Payment',
+]);
+
+const softDeleteExtension = Prisma.defineExtension((client) => {
+  return client.$extends({
+    query: {
+      $allModels: {
+        async $allOperations({
+          model,
+          operation,
+          args,
+          query,
+        }: {
+          model: any;
+          operation: Operation;
+          args: any;
+          query: any;
+        }) {
+          logger.debug(
+            {
+              target: 'prisma',
+              event: 'query',
+              model,
+              operation,
+              args,
+              query,
+            },
+            'prisma query 확장',
+          );
+          if (!SOFT_DELETE_MODELS.has(model)) return query(args);
+
+          const modelObject = (client as any)[model];
+
+          if (['findMany', 'findFirst', 'findUnique', 'count', 'groupBy', 'aggregate'].includes(operation)) {
+            if (operation === 'findUnique') {
+              // Prisma's findUnique doesn't support additional filters, so switch to findFirst
+              return modelObject.findFirst(args);
+            }
+
+            args ||= {};
+            args.where ||= {};
+            args.where.deletedAt = null;
+          } else if (['update', 'updateMany', 'upsert'].includes(operation)) {
+            args ||= {};
+            args.where ||= {};
+            args.where.deletedAt = null;
+          } else if (['delete', 'deleteMany'].includes(operation)) {
+            if (operation === 'delete') {
+              logger.debug(
+                {
+                  target: 'prisma',
+                  event: 'soft-delete',
+                  model,
+                  where: args.where,
+                  reason: args.reason,
+                },
+                'Soft delete 실행 (delete -> update)',
+              );
+
+              return modelObject.update({
+                where: args.where,
+                data: {
+                  deletedAt: new Date(),
+                  ...(args.reason ? { reason: args.reason } : {}),
+                },
+              });
+            }
+          } else {
+            logger.debug(`SoftDeleteExtension: Operation '${operation}' 지원 안 됨`);
+          }
+          return query(args);
         },
-      } as Prisma.Args<T, 'update'>);
+      },
     },
-  };
-}
-
-const prisma = new PrismaClient().$extends({
-  model: {
-    user: softDelete(),
-    device: softDelete(),
-    refreshToken: softDelete(),
-    store: softDelete(),
-    product: softDelete(),
-    order: softDelete(),
-    orderItem: softDelete(),
-    payment: softDelete(),
-  },
+  });
 });
+
+const prisma = new PrismaClient().$extends(softDeleteExtension);
 
 export default prisma;

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,15 +1,27 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Prisma, PrismaClient } from '@prisma/client';
 import type { Operation } from '@prisma/client/runtime/binary';
 
 import logger from './logger.js';
 
+/**
+ * Soft delete 기능이 포함된 확장 Prisma 클라이언트
+ */
 export type ExtendedPrismaClient = typeof prisma;
+
+/**
+ * prisma.$transaction()에서 사용할 트랜잭션 클라이언트 타입
+ */
 export type ExtendedTransactionClient = Parameters<Parameters<ExtendedPrismaClient['$transaction']>[0]>[0];
 
+/**
+ * 삭제 사유를 포함하는 확장 delete 인자
+ */
 export type ExtendedDeleteArgs<T> = T & { reason?: string };
 
-const SOFT_DELETE_MODELS = new Set([
+/**
+ * Soft delete 기능을 지원하는 모델 목록
+ */
+const SOFT_DELETE_MODELS = [
   'User',
   'Device',
   'RefreshToken',
@@ -18,75 +30,164 @@ const SOFT_DELETE_MODELS = new Set([
   'Order',
   'OrderItem',
   'Payment',
-]);
+] as const;
 
+/**
+ * Soft delete를 지원하는 모델 이름 타입
+ */
+type SoftDeleteModel = (typeof SOFT_DELETE_MODELS)[number];
+
+const READ_OPERATIONS: readonly Operation[] = [
+  'findMany',
+  'findFirst',
+  'findUnique',
+  'count',
+  'groupBy',
+  'aggregate',
+] as const;
+const UPDATE_OPERATIONS: readonly Operation[] = ['update', 'updateMany', 'upsert'] as const;
+const DELETE_OPERATIONS: readonly Operation[] = ['delete', 'deleteMany'] as const;
+
+/**
+ * 모델이 soft delete를 지원하는지 확인하는 타입 가드
+ */
+function isSoftDeleteModel(model: string): model is SoftDeleteModel {
+  return SOFT_DELETE_MODELS.includes(model as SoftDeleteModel);
+}
+
+/**
+ * 쿼리 인자에 deletedAt: null 필터 추가
+ */
+function addSoftDeleteFilter(args: Record<string, unknown>): void {
+  if (!args.where || typeof args.where !== 'object') {
+    args.where = {};
+  }
+  (args.where as Record<string, unknown>).deletedAt = null;
+}
+
+/**
+ * Soft delete 필터를 추가하여 읽기 작업 처리
+ */
+function handleReadOperation(
+  operation: Operation,
+  args: Record<string, unknown>,
+  client: PrismaClient,
+  model: string,
+  query: (args: Record<string, unknown>) => Promise<unknown>,
+): Promise<unknown> {
+  if (operation === 'findUnique') {
+    // findUnique는 추가 필터를 지원하지 않으므로 findFirst로 전환
+    logger.debug(
+      { target: 'prisma', event: 'findUnique-redirect', model },
+      'Soft delete 지원을 위해 findUnique를 findFirst로 리다이렉트',
+    );
+    const modelDelegate = (client as unknown as Record<string, Record<string, unknown>>)[model];
+    const findFirst = modelDelegate?.['findFirst'] as ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+
+    if (typeof findFirst === 'function') {
+      addSoftDeleteFilter(args);
+      return findFirst(args);
+    }
+  }
+
+  addSoftDeleteFilter(args);
+  return query(args);
+}
+
+/**
+ * Soft delete 필터를 추가하여 업데이트 작업 처리
+ */
+function handleUpdateOperation(
+  args: Record<string, unknown>,
+  query: (args: Record<string, unknown>) => Promise<unknown>,
+): Promise<unknown> {
+  addSoftDeleteFilter(args);
+  return query(args);
+}
+
+/**
+ * Delete 작업을 soft delete(update)로 변환하여 처리
+ */
+function handleDeleteOperation(
+  operation: Operation,
+  args: ExtendedDeleteArgs<Record<string, unknown>>,
+  client: PrismaClient,
+  model: string,
+): Promise<unknown> {
+  if (operation === 'delete') {
+    logger.debug(
+      {
+        target: 'prisma',
+        event: 'soft-delete',
+        model,
+        where: args.where,
+        reason: args.reason,
+      },
+      'Delete를 soft delete로 변환 (deletedAt을 설정하는 update)',
+    );
+
+    const modelDelegate = (client as unknown as Record<string, Record<string, unknown>>)[model];
+    const update = modelDelegate?.['update'] as ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
+
+    if (typeof update === 'function') {
+      const updateArgs: Record<string, unknown> = {
+        where: args.where,
+        data: {
+          deletedAt: new Date(),
+          ...(args.reason ? { reason: args.reason } : {}),
+        },
+      };
+      return update(updateArgs);
+    }
+  }
+
+  // deleteMany는 현재 soft delete에서 지원되지 않음
+  logger.warn({ target: 'prisma', operation, model }, 'Soft-delete 모델에서 deleteMany 작업 - 필요시 구현 고려');
+
+  throw new Error(`작업 '${operation}'은 soft delete 모델에서 지원되지 않습니다. 'delete'를 사용하세요.`);
+}
+
+/**
+ * Prisma 클라이언트용 Soft delete 확장
+ * Soft delete된 레코드를 자동으로 필터링하고 delete 작업을 update로 변환
+ */
 const softDeleteExtension = Prisma.defineExtension((client) => {
   return client.$extends({
     query: {
       $allModels: {
-        async $allOperations({
-          model,
-          operation,
-          args,
-          query,
-        }: {
-          model: any;
-          operation: Operation;
-          args: any;
-          query: any;
-        }) {
+        async $allOperations({ model, operation, args, query }) {
           logger.debug(
             {
               target: 'prisma',
               event: 'query',
               model,
               operation,
-              args,
-              query,
             },
-            'prisma query 확장',
+            'Soft delete 확장에서 Prisma 쿼리 인터셉트',
           );
-          if (!SOFT_DELETE_MODELS.has(model)) return query(args);
 
-          const modelObject = (client as any)[model];
-
-          if (['findMany', 'findFirst', 'findUnique', 'count', 'groupBy', 'aggregate'].includes(operation)) {
-            if (operation === 'findUnique') {
-              // Prisma's findUnique doesn't support additional filters, so switch to findFirst
-              return modelObject.findFirst(args);
-            }
-
-            args ||= {};
-            args.where ||= {};
-            args.where.deletedAt = null;
-          } else if (['update', 'updateMany', 'upsert'].includes(operation)) {
-            args ||= {};
-            args.where ||= {};
-            args.where.deletedAt = null;
-          } else if (['delete', 'deleteMany'].includes(operation)) {
-            if (operation === 'delete') {
-              logger.debug(
-                {
-                  target: 'prisma',
-                  event: 'soft-delete',
-                  model,
-                  where: args.where,
-                  reason: args.reason,
-                },
-                'Soft delete 실행 (delete -> update)',
-              );
-
-              return modelObject.update({
-                where: args.where,
-                data: {
-                  deletedAt: new Date(),
-                  ...(args.reason ? { reason: args.reason } : {}),
-                },
-              });
-            }
-          } else {
-            logger.debug(`SoftDeleteExtension: Operation '${operation}' 지원 안 됨`);
+          // Soft delete를 지원하지 않는 모델은 확장 건너뛰기
+          if (!isSoftDeleteModel(model)) {
+            return query(args);
           }
+
+          // 읽기 작업 처리
+          if (READ_OPERATIONS.includes(operation)) {
+            return handleReadOperation(operation, args, client as PrismaClient, model, query);
+          }
+
+          // 업데이트 작업 처리
+          if (UPDATE_OPERATIONS.includes(operation)) {
+            return handleUpdateOperation(args, query);
+          }
+
+          // 삭제 작업 처리
+          if (DELETE_OPERATIONS.includes(operation)) {
+            return handleDeleteOperation(operation, args, client as PrismaClient, model);
+          }
+
+          // 지원하지 않는 작업 - 그대로 통과
+          logger.debug({ target: 'prisma', operation, model }, 'Soft delete 확장에서 처리하지 않는 작업, 그대로 통과');
           return query(args);
         },
       },

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -4,6 +4,9 @@ import type { Operation } from '@prisma/client/runtime/binary';
 
 import logger from './logger.js';
 
+export type ExtendedPrismaClient = typeof prisma;
+export type ExtendedTransactionClient = Parameters<Parameters<ExtendedPrismaClient['$transaction']>[0]>[0];
+
 export type ExtendedDeleteArgs<T> = T & { reason?: string };
 
 const SOFT_DELETE_MODELS = new Set([

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,94 +1,42 @@
-import { DeletedTokenReason, PrismaClient } from '@prisma/client';
-import { createSoftDeleteExtension } from 'prisma-extension-soft-delete';
+import { DeletedTokenReason, Prisma, PrismaClient } from '@prisma/client';
 
-const basePrisma = new PrismaClient()
-  .$extends({
-    name: 'skipRemover',
-    query: {
-      $allModels: {
-        async update({ args, query }) {
-          if (args.data) {
-            args.data = removeSkipFields(args.data);
-          }
-          return query(args);
+type UpdateDelegate<T> = {
+  update(
+    args: Prisma.Args<T, 'update'>
+  ): Prisma.Result<T, Prisma.Args<T, 'update'>, 'update'>;
+};
+
+export const softDelete = () => {
+  return {
+    async delete<T>(
+      this: T,
+      args: Prisma.Args<T, 'delete'> & { reason?: DeletedTokenReason}
+    ): Promise<Prisma.Result<T, Prisma.Args<T, 'update'>, 'update'>> {
+      const ctx =
+        Prisma.getExtensionContext(this) as unknown as UpdateDelegate<T>;
+
+      return ctx.update({
+        where: args.where,
+        data: {
+          deletedAt: new Date(),
+          ...(args.reason ? { reason: args.reason } : {}),
         },
-        async updateMany({ args, query }) {
-          if (args.data) {
-            args.data = removeSkipFields(args.data);
-          }
-          return query(args);
-        },
-      },
+      } as Prisma.Args<T, 'update'>);
     },
-  })
-  .$extends(
-    createSoftDeleteExtension({
-      models: {
-        User: true,
-        Device: true,
-        RefreshToken: true,
-        Store: true,
-        Product: true,
-        Order: true,
-        OrderItem: true,
-        Payment: true,
-      },
-      defaultConfig: {
-        field: 'deletedAt',
-        createValue: (deleted) => {
-          if (deleted) return new Date();
-          return null;
-        },
-      },
-    }),
-  );
+  };
+}
 
-// 리프레시 토큰 소프트삭제 확장
-const prisma = basePrisma.$extends({
+const prisma = new PrismaClient().$extends({
   model: {
-    refreshToken: {
-      async deleteWithReason(args: { where: { jti: string }; reason: DeletedTokenReason }) {
-        return await basePrisma.refreshToken.update({
-          where: args.where,
-          data: {
-            reason: args.reason,
-            deletedAt: new Date(),
-          },
-        });
-      },
-    },
+    user: softDelete(),
+    device: softDelete(),
+    refreshToken: softDelete(),
+    store: softDelete(),
+    product: softDelete(),
+    order: softDelete(),
+    orderItem: softDelete(),
+    payment: softDelete(),
   },
 });
-
-/**
- * update, updateMany에서 빈 객체 제거
- *
- * soft delete 확장 설치 없을 때는
- * schema.prisma에서 `previewFeatures = ["strictUndefinedChecks"]` 설정 후에
- * `?? Prisma.skip` 로 사용하면 빈 객체는 업데이트 안 하고 스킵되는데
- * 확장 사용시 에러 발생
- * TODO: 추후 더 자세한 원인 분석과 해결 방법 찾아봐야함
- */
-const removeSkipFields = <T extends Record<string, unknown>>(data: T): T => {
-  if (!data || typeof data !== 'object') return data;
-
-  const result: Record<string, unknown> = {};
-
-  for (const [key, value] of Object.entries(data)) {
-    const isEmpty =
-      value && // null, undefined 가 아닌 값
-      typeof value === 'object' && // 객체 타입
-      !Array.isArray(value) && // 배열이 아닌 값
-      !(value instanceof Date) && // Date 객체 아닌 값
-      Object.keys(value).length === 0; // 빈 객체인 경우
-
-    // 빈 객체가 아닌 필드만 결과에 포함
-    if (!isEmpty) {
-      result[key] = value;
-    }
-  }
-
-  return result as T;
-};
 
 export default prisma;

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -114,6 +114,12 @@ function handleDeleteOperation(
   client: PrismaClient,
   model: string,
 ): Promise<unknown> {
+  const modelDelegate = (client as unknown as Record<string, Record<string, unknown>>)[model];
+  const deletedAtData = {
+    deletedAt: new Date(),
+    ...(args.reason ? { reason: args.reason } : {}),
+  };
+
   if (operation === 'delete') {
     logger.debug(
       {
@@ -126,25 +132,46 @@ function handleDeleteOperation(
       'Delete를 soft delete로 변환 (deletedAt을 설정하는 update)',
     );
 
-    const modelDelegate = (client as unknown as Record<string, Record<string, unknown>>)[model];
     const update = modelDelegate?.['update'] as ((args: Record<string, unknown>) => Promise<unknown>) | undefined;
 
     if (typeof update === 'function') {
-      const updateArgs: Record<string, unknown> = {
+      return update({
         where: args.where,
-        data: {
-          deletedAt: new Date(),
-          ...(args.reason ? { reason: args.reason } : {}),
-        },
-      };
-      return update(updateArgs);
+        data: deletedAtData,
+      });
+    }
+  } else if (operation === 'deleteMany') {
+    logger.debug(
+      {
+        target: 'prisma',
+        event: 'soft-delete-many',
+        model,
+        where: args.where,
+        reason: args.reason,
+      },
+      'DeleteMany를 soft delete로 변환 (deletedAt을 설정하는 updateMany)',
+    );
+
+    const updateMany = modelDelegate?.['updateMany'] as
+      | ((args: Record<string, unknown>) => Promise<unknown>)
+      | undefined;
+
+    if (typeof updateMany === 'function') {
+      return updateMany({
+        where: args.where,
+        data: deletedAtData,
+      });
     }
   }
 
-  // deleteMany는 현재 soft delete에서 지원되지 않음
-  logger.warn({ target: 'prisma', operation, model }, 'Soft-delete 모델에서 deleteMany 작업 - 필요시 구현 고려');
+  // 이 지점에 도달하는 경우: modelDelegate가 없거나 update/updateMany 메서드를 찾을 수 없는 경우
+  // 정상적인 상황에서는 발생하지 않지만, 방어적으로 에러를 로깅하고 원래 쿼리를 실행
+  logger.error(
+    { target: 'prisma', operation, model },
+    'Soft delete 변환 실패: 모델 delegate 또는 메서드를 찾을 수 없음',
+  );
 
-  throw new Error(`작업 '${operation}'은 soft delete 모델에서 지원되지 않습니다. 'delete'를 사용하세요.`);
+  throw new Error(`${model} 모델에서 ${operation} 작업을 soft delete로 변환할 수 없습니다.`);
 }
 
 /**

--- a/test.md
+++ b/test.md
@@ -1,1 +1,0 @@
-# git ci cache test

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+# git ci cache test


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
- soft delete
- 유저, 인증 트랜잭션
- 오타 수정
- 로깅 수정
- 인덱스 추가
- 유저 삭제시 모든 토큰 삭제 기능 추가
- 깃액션 노드 모듈 캐싱 수정

<!-- 작업한 내용을 간략하게 요약해주세요. -->

## 📚 관련 이슈 (Related Issues)
closes #63 #93 #84 
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123 -->

## ✨ 핵심 변경 사항 (Core Changes)
- soft delete 
  - delete, deleteMany
  - update, updateMany, upsert
  - findFirst, findUnique, findMany, count, groupBy, aggregate
- 유저, 인증 트랜잭션
  - 인증, 로그인
    - 디바이스 찾기, 디바이스 만들기, 토큰 만들고 저장하기 
    - 디바이스 수량 조회하기, 마지막으로 사용한 디바이스 조회하기, 디바이스 삭제하기, 리프레시 토큰 삭제하기
  - 유저 삭제 
    - 사용자의 모든 디바이스 조회, 모든 리프레시 토큰 삭제, 유저 삭제
    - 유저 삭제시 현재 토큰 삭제에서 모든 토큰 삭제로 변경
    - 디바이스, 스토어, 리뷰 등 추가적으로 작업해야할 것들이 아직 많이 남아있음 
- 오타 수정
  - http-exception.ts, constant.ts 파일 
  - emailAready -> emailAlready
- 로깅 수정
  - 500 이상 에러는 error, 미만은 warn으로 수정
  - 스택트레이스 가독성을 위해서 배열 정리 및 프로젝트 루트 기준으로 수정
  - body, query, params를 request 안으로 정리
  - 로깅 메시지 추가
  - <img width="546" height="323" alt="image" src="https://github.com/user-attachments/assets/a854e2e2-50aa-4627-9f41-bc647516ed08" />
- 인덱스 추가
  - 리프레시 토큰 (deviceId, deletedAt) 
- 깃액션 노드 모듈 캐싱 수정
  - 기존 캐시를 찾을 수 없는 에러 수정 -> 약 15s 시간 감소
  - <img width="620" height="246" alt="image" src="https://github.com/user-attachments/assets/9f611135-26af-4deb-80cd-6544e04842ca" />
  - <img width="622" height="82" alt="image" src="https://github.com/user-attachments/assets/533af180-1fde-4201-a120-702fae682a6b" />


<!-- 주요 변경사항을 자세히 작성해주세요. -->

## 📸 스크린샷 또는 비디오 (Screenshots or Videos)

<!-- UI 변경이 있다면 스크린샷 또는 비디오를 첨부해주세요. -->

## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
soft delete가 잘 적용되는지 확인해주세요

<!-- 리뷰어가 집중해야 할 부분을 알려주세요. -->

## ✅ 체크리스트 (Checklist)

- [x] 빌드 및 테스트를 통과했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 리뷰어에게 필요한 모든 정보를 제공했습니다.
