### PR TITLE
[Feat] s3 로깅+db 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 /src/generated/prisma
 logs
+test.jpg

--- a/prisma/migrations/20251231054044_add_image_model/migration.sql
+++ b/prisma/migrations/20251231054044_add_image_model/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Image" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "originalName" TEXT,
+    "mimeType" TEXT,
+    "size" INTEGER,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Image_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Image" ADD CONSTRAINT "Image_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model User {
   password String
   name     String
   type     UserRole @default(BUYER)
-  image    String? // 프로필 이미지
+  image    String? // 프로필 이미지 URL (단순 문자열)
 
   points      Int @default(0)
   totalAmount Int @default(0) // 누적 구매 금액
@@ -44,7 +44,7 @@ model User {
   notifications  Notification[] // 알림 목록
   pointHistories PointHistory[]
   devices        Device[]
-
+  uploadedImages Image[]
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   lastLoginAt DateTime?
@@ -63,16 +63,16 @@ enum DeletedTokenReason {
 }
 
 model RefreshToken {
-  id         String              @id @default(cuid())
-  jti        String              @unique
-  deviceId   String
-  device     Device              @relation(fields: [deviceId], references: [id], onDelete: Cascade)
-  reason     DeletedTokenReason? // 토큰 무효화 이유
-  issuedAt   DateTime // 토큰 발급 시간
-  expiresAt  DateTime // 만료 날짜
-  updatedAt  DateTime            @updatedAt
+  id        String          @id @default(cuid())
+  jti       String          @unique
+  deviceId  String
+  device    Device          @relation(fields: [deviceId], references: [id], onDelete: Cascade)
+  reason    DeletedTokenReason? // 토큰 무효화 이유
+  issuedAt  DateTime // 토큰 발급 시간
+  expiresAt DateTime // 만료 날짜
+  updatedAt DateTime        @updatedAt
   lastUsedAt DateTime // 마지막 사용 시간
-  deletedAt  DateTime? // 무효화 된 시간
+  deletedAt DateTime? // 무효화 된 시간
 
   @@index([deletedAt])
   @@index([issuedAt])
@@ -183,8 +183,8 @@ model Size {
   // 다국어 지원을 위해 JSON 타입 사용 (PostgreSQL 지원)
   sizeDetail Json?
 
-  stocks     ProductStock[] // 재고
-  cartItems  CartItem[]
+  stocks    ProductStock[] // 재고
+  cartItems CartItem[]
   orderItems OrderItem[]
 }
 
@@ -212,8 +212,8 @@ model Product {
   categoryId String?
   category   Category? @relation(fields: [categoryId], references: [id])
 
-  stocks    ProductStock[]
-  reviews   Review[]
+  stocks  ProductStock[]
+  reviews Review[]
   inquiries Inquiry[]
 
   cartItems  CartItem[]
@@ -458,10 +458,28 @@ model Notification {
   type      NotificationType
   isChecked Boolean          @default(false) // 읽음 여부
   url       String?          // 클릭 시 이동할 링크 (/product/123 등)
-  
+   
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+// ==========================================
+// 9. 이미지 관리
+// ==========================================
+
+model Image {
+  id           String   @id @default(cuid())
+  key          String   // S3 객체 Key (삭제 시 필요)
+  url          String   // 접근 URL (CDN/S3)
+  originalName String?  // 원본 파일명
+  mimeType     String?  // 파일 타입 (image/jpeg 등)
+  size         Int?     // 파일 크기 (Byte)
+
+  userId       String?  // 업로더 ID (누가 올렸는지 추적)
+  user         User?    @relation(fields: [userId], references: [id])
+
+  createdAt    DateTime @default(now())
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,7 @@ export const config = {
     rateLimitMax: Number(process.env['RATE_LIMIT_MAX']) || 100, // 시간 제한당 허용 요청 수
     compression_threshold: Number(process.env['COMPRESSION_THRESHOLD']) || 1024, // gzip 최소 크기
     compression_level: Number(process.env['COMPRESSION_LEVEL']) || 6, // gzip 압축 레벨
+    fileSizeLimit: Number(process.env['FILE_SIZE_LIMIT']) || 5 * 1024 * 1024, // 5MB
     cookieMaxAge: ms((process.env['REFRESH_TOKEN_EXPIRES_IN'] as StringValue) ?? '7d'),
   },
   auth: {

--- a/src/controllers/s3.controller.ts
+++ b/src/controllers/s3.controller.ts
@@ -1,7 +1,9 @@
 import type { NextFunction, Request, Response } from 'express';
 
 import { MESSAGE, STATUS_CODE } from '../constants/constant.js';
+import { s3Service } from '../services/s3.service.js';
 import { HttpException } from '../utils/http-exception.js';
+import logger from '../utils/logger.js';
 
 interface MulterS3File extends Express.Multer.File {
   location: string;
@@ -11,19 +13,23 @@ interface MulterS3File extends Express.Multer.File {
 class S3Controller {
   uploadImage = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      if (!req.file) {
+      const { user, file } = req;
+
+      if (!file) {
         throw HttpException.badRequest('업로드할 파일이 없습니다.');
       }
+      if (!user) {
+        throw HttpException.unauthorized('인증된 사용자가 아닙니다.');
+      }
 
-      const fileInfo = req.file as MulterS3File;
+      const fileInfo = file as MulterS3File;
+      const imageData = await s3Service.saveImage(file, fileInfo, user.id);
 
-      const fileUrl = fileInfo.location;
-      const fileKey = fileInfo.key;
+      logger.info(`[IMAGE_UPLOAD] User(id: ${user.id}) uploaded a file. Key: ${fileInfo.key}, Size: ${file.size}`);
 
       return res.status(STATUS_CODE.OK).json({
         message: MESSAGE.uploadSuccess,
-        url: fileUrl,
-        key: fileKey,
+        data: imageData,
       });
     } catch (err) {
       next(err);

--- a/src/middlewares/upload.middleware.ts
+++ b/src/middlewares/upload.middleware.ts
@@ -72,7 +72,7 @@ const upload = multer({
     cb(null, true);
   },
   limits: {
-    fileSize: 5 * 1024 * 1024, // 5MB 제한
+    fileSize: config.app.fileSizeLimit,
   },
 });
 
@@ -82,7 +82,9 @@ export const uploadImage = (req: Request, res: Response, next: NextFunction) => 
     if (err instanceof MulterError) {
       switch (err.code) {
         case 'LIMIT_FILE_SIZE':
-          return next(HttpException.badRequest('파일 크기는 5MB를 초과할 수 없습니다.'));
+          return next(
+            HttpException.badRequest(`파일 크기는 ${config.app.fileSizeLimit / 1024 / 1024}MB를 초과할 수 없습니다.`),
+          );
         case 'LIMIT_UNEXPECTED_FILE':
           return next(HttpException.badRequest('하나의 파일만 업로드할 수 있습니다.'));
         default:

--- a/src/repositories/image.repository.ts
+++ b/src/repositories/image.repository.ts
@@ -1,0 +1,11 @@
+import type { Prisma } from '@prisma/client';
+
+import prisma from '../utils/prisma.js';
+
+class ImageRepository {
+  async createImage(data: Prisma.ImageUncheckedCreateInput) {
+    return prisma.image.create({ data });
+  }
+}
+
+export const imageRepository = new ImageRepository();

--- a/src/routes/s3.router.ts
+++ b/src/routes/s3.router.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 
 import { s3Controller } from '../controllers/s3.controller.js';
+import { authMiddleware } from '../middlewares/auth.middleware.js';
 import { uploadImage } from '../middlewares/upload.middleware.js';
 
 export const s3Router = express.Router();
 
 // POST /api/s3/upload
-s3Router.post('/upload', uploadImage, s3Controller.uploadImage);
+s3Router.post('/upload', authMiddleware, uploadImage, s3Controller.uploadImage);

--- a/src/serializes/s3.serialize.ts
+++ b/src/serializes/s3.serialize.ts
@@ -1,0 +1,10 @@
+import type { Image } from '@prisma/client';
+
+export class S3Response {
+  static base(image: Image) {
+    return {
+      url: image.url,
+      key: image.key,
+    };
+  }
+}

--- a/src/services/s3.service.ts
+++ b/src/services/s3.service.ts
@@ -1,0 +1,32 @@
+import { Prisma } from '@prisma/client';
+
+import { imageRepository } from '../repositories/image.repository.js';
+import { S3Response } from '../serializes/s3.serialize.js';
+import { HttpException } from '../utils/http-exception.js';
+
+class S3Service {
+  saveImage = async (file: Express.Multer.File, fileInfo: { location: string; key: string }, userId: string) => {
+    try {
+      const { originalname, mimetype, size } = file;
+      const { location: url, key } = fileInfo;
+
+      const savedImage = await imageRepository.createImage({
+        key,
+        url,
+        originalName: originalname,
+        mimeType: mimetype,
+        size,
+        userId,
+      });
+
+      return S3Response.base(savedImage);
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2003') {
+        throw HttpException.badRequest('유효하지 않은 사용자 ID 입니다.');
+      }
+      throw err;
+    }
+  };
+}
+
+export const s3Service = new S3Service();

--- a/test-https/s3.http
+++ b/test-https/s3.http
@@ -2,51 +2,93 @@
 ### 환경 변수 설정
 @host = http://localhost:3001
 @boundary = ----WebKitFormBoundary7MA4YWxkTrZu0gW
+@newUserEmail = test@test.com
+@newUserPassword = testtest
+
+# =======================================================
+# 1단계: 인증 (로그인 및 토큰 획득)
+# =======================================================
+
+# 1. [회원가입] 테스트용 유저 생성
+POST {{host}}/api/users
+Content-Type: application/json
+
+{
+  "name": "테스트유저",
+  "email": "{{newUserEmail}}",
+  "password": "{{newUserPassword}}",
+  "type": "BUYER"
+}
+
+###
+
+# 2. [로그인] Access Token 발급 받기
+# @name auth 
+POST {{host}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{newUserEmail}}",
+  "password": "{{newUserPassword}}"
+}
+
+###
+
+# 3. [변수 저장] 토큰 자동 추출
+@token = {{auth.response.body.accessToken}}
+
+
+# =======================================================
+# 2단계: 이미지 업로드 테스트 (성공 & 실패)
+# =======================================================
 
 # -------------------------------------------------------
-# 1. [성공 케이스] 정상적인 JPG 이미지 업로드
+# Case A. [성공] 정상적인 JPG 이미지 업로드
 # -------------------------------------------------------
-# 예상 결과: 200 OK (업로드 성공)
+# 예상 결과: 200 OK
 POST {{host}}/api/s3/upload
+Authorization: Bearer {{token}}
 Content-Type: multipart/form-data; boundary={{boundary}}
 
 --{{boundary}}
 Content-Disposition: form-data; name="image"; filename="test.jpg"
 Content-Type: image/jpeg
 
-< ./test.jpg
+< ../test.jpg
 --{{boundary}}--
 
 ###
 
 # -------------------------------------------------------
-# 2. [실패 케이스] 가짜 이미지 파일 (MIME Type 불일치)
+# Case B. [실패] 가짜 이미지 파일 (MIME Type 불일치)
 # -------------------------------------------------------
-# 시나리오: 확장자는 .jpg지만, 실제 타입(Content-Type)은 text/plain인 경우
-# 예상 결과: 400 Bad Request ("파일 확장자와 실제 파일 유형이 일치하지 않습니다.")
+# 시나리오: 확장자는 .jpg지만, 실제 내용(Content-Type)은 text/plain인 경우
+# 예상 결과: 400 Bad Request
 POST {{host}}/api/s3/upload
+Authorization: Bearer {{token}}
 Content-Type: multipart/form-data; boundary={{boundary}}
 
 --{{boundary}}
 Content-Disposition: form-data; name="image"; filename="fake.jpg"
 Content-Type: text/plain
 
-< ./fake.jpg
+< ../fake.jpg
 --{{boundary}}--
 
 ###
 
 # -------------------------------------------------------
-# 3. [실패 케이스] 허용되지 않은 확장자 (.txt)
+# Case C. [실패] 허용되지 않은 확장자 (.txt)
 # -------------------------------------------------------
-# 시나리오: 그냥 대놓고 .txt 파일을 올리는 경우
-# 예상 결과: 400 Bad Request ("허용되지 않는 확장자입니다: txt")
+# 시나리오: 이미지 파일이 아닌 .txt 파일을 올리는 경우
+# 예상 결과: 400 Bad Request
 POST {{host}}/api/s3/upload
+Authorization: Bearer {{token}}
 Content-Type: multipart/form-data; boundary={{boundary}}
 
 --{{boundary}}
 Content-Disposition: form-data; name="image"; filename="memo.txt"
 Content-Type: text/plain
 
-< ./fake.jpg
+< ../fake.jpg
 --{{boundary}}--


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
기존의 단순 S3 업로드 방식을 개선하여, 이미지 업로드 시 DB에 메타데이터를 저장하도록 리팩토링했습니다. 또한 운영 관리를 위해 업로더 추적(로그인 필수) 및 구조화된 로깅 기능을 추가했습니다.

## 📚 관련 이슈 (Related Issues)
Closes #90

## ✨ 핵심 변경 사항 (Core Changes)
1. DB 스키마 변경 (prisma/schema.prisma)

Image 모델을 추가하여 S3 Key, URL, 파일 크기, 원본 파일명 등을 저장하도록 했습니다.

User 모델과 관계를 맺어 누가 업로드했는지 추적 가능하게 변경했습니다.

2. 보안 및 설정 강화

s3.router.ts: authMiddleware를 추가하여 로그인한 유저만 업로드 가능하도록 제한 (401 처리)

config.ts: 하드코딩되어 있던 파일 크기 제한(5MB)을 환경 변수 및 설정 파일로 분리

3. 로깅 추가

업로드 성공 시 [IMAGE_UPLOAD] 태그와 함께 유저 ID, 파일 Key, 용량을 로그로 남기도록 구현

## 📸 스크린샷 또는 비디오 (Screenshots or Videos)
[서버 로그 확인] 정상 업로드 시 아래와 같이 유저 정보와 파일 메타데이터가 기록됩니다.
<img width="1653" height="677" alt="image" src="https://github.com/user-attachments/assets/abbddc6a-d2d8-491c-86fa-9fbc7162832c" />


[DB 저장 확인 (Prisma Studio)] Image 테이블에 데이터가 정상적으로 저장됨을 확인했습니다.
<img width="2205" height="1794" alt="image" src="https://github.com/user-attachments/assets/1a9ef3ce-620e-48bf-adac-33e2d2654c05" />

## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
s3.service.ts에서 리턴 타입을 Image 모델 대신 S3Response 시리얼라이저를 사용하도록 변경했습니다. 이 구조가 팀 컨벤션에 적절한지 확인 부탁드립니다.

마이그레이션 파일이 포함되어 있으니, 로컬 테스트 시 npx prisma migrate dev 실행이 필요합니다.

## ✅ 체크리스트 (Checklist)
[x] 빌드 및 테스트를 통과했습니다.

[x] 코드 스타일 가이드라인을 준수했습니다. (ESLint, Prettier 확인 완료)

[x] 리뷰어에게 필요한 모든 정보를 제공했습니다.