### PR TITLE
[Ref] 글로벌 에러 핸들러 자동 매핑

### DIFF
--- a/src/constants/constant.ts
+++ b/src/constants/constant.ts
@@ -36,12 +36,3 @@ export const MESSAGE = {
   tooManyRequests: '요청이 너무 많습니다. 잠시 후 시도해주세요',
   serverError: '문제가 발생했습니다. 나중에 다시 시도하세요',
 };
-
-export const ERROR_NAME = {
-  BAD_REQUEST: 'Bad Request',
-  UNAUTHORIZED: 'Unauthorized',
-  FORBIDDEN: 'Forbidden',
-  NOT_FOUND: 'Not Found',
-  CONFLICT: 'Conflict',
-  INTERNAL_SERVER_ERROR: 'Internal Server Error',
-};

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 
-import { ERROR_NAME, MESSAGE, STATUS_CODE } from '../constants/constant.js';
+import { MESSAGE, STATUS_CODE } from '../constants/constant.js';
 import { HttpException } from '../utils/http-exception.js';
 import logger from '../utils/logger.js';
 
@@ -26,7 +26,7 @@ export const errorMiddleware = (err: Error | HttpException, req: Request, res: R
     }
   }
 
-  // 에러 이름 결정 (Swagger용)
+  // 에러 이름 결정 (자동 변환 로직 사용)
   const errorName = getErrorName(status);
 
   // 로깅
@@ -50,22 +50,20 @@ export const errorMiddleware = (err: Error | HttpException, req: Request, res: R
   });
 };
 
-// [보조 함수]
+// [보조 함수] 상태 코드로 에러 이름 자동 생성
+// 예: 400 -> 'BAD_REQUEST' 찾음 -> 'Bad Request'로 변환
 function getErrorName(status: number): string {
-  switch (status) {
-    case STATUS_CODE.BAD_REQUEST:
-      return ERROR_NAME.BAD_REQUEST;
-    case STATUS_CODE.UNAUTHORIZED:
-      return ERROR_NAME.UNAUTHORIZED;
-    case STATUS_CODE.FORBIDDEN:
-      return ERROR_NAME.FORBIDDEN;
-    case STATUS_CODE.NOT_FOUND:
-      return ERROR_NAME.NOT_FOUND;
-    case STATUS_CODE.CONFLICT:
-      return ERROR_NAME.CONFLICT;
-    case STATUS_CODE.INTERNAL_SERVER_ERROR:
-      return ERROR_NAME.INTERNAL_SERVER_ERROR;
-    default:
-      return 'Error';
+  // 1. STATUS_CODE 객체에서 value(숫자)가 status와 일치하는 key를 찾습니다.
+  const key = Object.keys(STATUS_CODE).find((k) => STATUS_CODE[k as keyof typeof STATUS_CODE] === status);
+
+  // 2. 키를 못 찾으면 기본값 반환
+  if (!key) {
+    return 'Error';
   }
+
+  // 3. 변환 로직: "BAD_REQUEST" -> "Bad Request"
+  return key
+    .split('_') // ['BAD', 'REQUEST'] 로 분리
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()) // ['Bad', 'Request'] 로 변환
+    .join(' '); // "Bad Request" 로 합침
 }


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
지난 PR 리뷰(#101)에서 제안해주신 의견을 반영하여, 글로벌 에러 핸들러의 에러 이름(Error Name) 생성 로직을 개선했습니다. 기존에는 상태 코드가 추가될 때마다 수동으로 업데이트해야 했으나, 이번 변경을 통해 STATUS_CODE 키값을 기반으로 에러 이름을 자동 생성하도록 리팩토링했습니다.

## 📚 관련 이슈 (Related Issues)
Closes #101

## ✨ 핵심 변경 사항 (Core Changes)
1. 중복 상수 제거 (src/constants/constant.ts)

STATUS_CODE와 1:1로 매핑되던 ERROR_NAME 객체를 삭제하여 데이터 중복을 제거했습니다.

2. 에러 이름 자동 변환 로직 구현 (src/middlewares/error.middleware.ts)

getErrorName 함수 내의 하드코딩된 switch-case문을 제거했습니다.

대신, STATUS_CODE의 키(Key)를 찾아 사람이 읽기 좋은 형태로 변환하는 로직을 적용했습니다.

예: BAD_REQUEST (400) -> Bad Request

예: INTERNAL_SERVER_ERROR (500) -> Internal Server Error

[변경 전 코드]

```
function getErrorName(status: number): string {
  switch (status) {
    case STATUS_CODE.BAD_REQUEST: return ERROR_NAME.BAD_REQUEST;
  }
}
```
[변경 후 코드]

```
function getErrorName(status: number): string {
  const key = Object.keys(STATUS_CODE).find((k) => STATUS_CODE[k] === status);
  if (!key) return 'Error';
  
  // 'BAD_REQUEST' -> 'Bad Request' 로 변환
  return key.split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
}
```

## 📸 스크린샷 또는 비디오 (Screenshots or Videos)

## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
getErrorName 함수 내부의 문자열 변환 로직(split, map, join)이 의도한 대로 동작하는지, 엣지 케이스는 없을지 확인 부탁드립니다.

## ✅ 체크리스트 (Checklist)
[x] 빌드 및 테스트를 통과했습니다.

[x] 코드 스타일 가이드라인을 준수했습니다.

[x] 리뷰어에게 필요한 모든 정보를 제공했습니다.