### PR TITLE
[Ref] SSE 배치 전송

### DIFF
--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -15,11 +15,18 @@ type CreateNotificationInput = {
 class NotificationService {
   // 한 유저가 여러 기기에서 접속할 수 있도록, Response 객체를 배열로 관리합니다.
   private clients: Map<string, Response[]> = new Map();
+  // 클라이언트별 알림 대기열
+  private notificationsQueue: Map<string, any[]> = new Map();
   // 동시 접속 허용 수
   private readonly MAX_CONNECTIONS = 3;
 
+  constructor() {
+    // 30초마다 버퍼링된 알림을 전송
+    setInterval(this.sendBufferedNotifications, 30000);
+  }
+
   /**
-   * 새로운 클라이언트를 추가합니다.
+   * 새로운 클라이언트를 추가하고, 알림 대기열을 초기화합니다.
    * @param userId - 사용자 ID
    * @param res - Express의 Response 객체
    */
@@ -37,6 +44,12 @@ class NotificationService {
 
     userClients.push(res);
     this.clients.set(userId, userClients);
+
+    // 새 클라이언트를 위한 알림 대기열 초기화
+    if (!this.notificationsQueue.has(userId)) {
+      this.notificationsQueue.set(userId, []);
+    }
+
     logger.info(`SSE: Client connected, userId: ${userId}. Total connections for user: ${userClients.length}`);
 
     // 연결이 끊겼을 때 해당 클라이언트만 목록에서 제거
@@ -48,7 +61,7 @@ class NotificationService {
   }
 
   /**
-   * 특정 클라이언트를 목록에서 제거합니다.
+   * 특정 클라이언트를 목록에서 제거하고, 연결이 없으면 대기열도 삭제합니다.
    * @param userId - 사용자 ID
    * @param resToRemove - 제거할 Express의 Response 객체
    */
@@ -64,18 +77,45 @@ class NotificationService {
     } else {
       // 해당 유저의 연결이 하나도 남지 않으면 Map에서 키를 삭제
       this.clients.delete(userId);
+      // 대기열도 함께 삭제
+      this.notificationsQueue.delete(userId);
     }
   }
 
   /**
-   * DB에 알림을 생성하고, 실시간으로 클라이언트에게 전송합니다.
+   * DB에 알림을 생성하고, 대기열에 추가합니다.
    * @param data - 생성할 알림 데이터
    */
   async createNotification(data: CreateNotificationInput) {
     const savedNotification = await notificationRepository.create(data);
-    this.sendNotification(data.userId, savedNotification);
+
+    // 해당 유저가 접속 중인지 확인
+    if (this.clients.has(data.userId)) {
+      const queue = this.notificationsQueue.get(data.userId) || [];
+      queue.push(savedNotification);
+      this.notificationsQueue.set(data.userId, queue);
+      logger.info(`SSE: Queued notification for userId: ${data.userId}. Queue size: ${queue.length}`);
+    }
+
     return savedNotification;
   }
+
+  /**
+   * 30초 주기로 대기열의 알림을 클라이언트에게 보냅니다.
+   * 대기열이 비어있으면 빈 배열을 보냅니다.
+   */
+  private sendBufferedNotifications = (): void => {
+    this.clients.forEach((_, userId) => {
+      const queue = this.notificationsQueue.get(userId) || [];
+      this.sendNotification(userId, queue);
+      // 전송 후 대기열 비우기
+      this.notificationsQueue.set(userId, []);
+
+      if (queue.length > 0) {
+        logger.info(`SSE: Flushed notification queue for userId: ${userId}. Sent ${queue.length} items.`);
+      }
+    });
+  };
 
   /**
    * 특정 유저의 알림 목록을 조회합니다.
@@ -107,15 +147,13 @@ class NotificationService {
    * 특정 사용자에게 알림을 보냅니다. (SSE 전송 전용)
    * 해당 유저의 모든 연결된 기기에 알림을 전송합니다.
    * @param userId - 알림을 받을 사용자 ID
-   * @param data - 전송할 데이터 (객체 형태)
+   * @param data - 전송할 데이터 (객체 또는 배열)
    */
   sendNotification(userId: string, data: unknown): void {
     const userClients = this.clients.get(userId);
 
     if (userClients && userClients.length > 0) {
-      const message = `data: ${JSON.stringify(data)}
-
-`;
+      const message = `data: ${JSON.stringify(data)}\n\n`;
 
       // 해당 유저의 모든 클라이언트에게 알림 전송
       userClients.forEach((client) => {
@@ -127,9 +165,11 @@ class NotificationService {
           this.removeClient(userId, client);
         }
       });
-      logger.info(`SSE: Sent notification to userId: ${userId} (${userClients.length} clients)`);
-    } else {
-      logger.warn(`SSE: Client not found for userId: ${userId}. Notification not sent.`);
+
+      // 데이터가 있을 때만 전송 로그를 남김
+      if (Array.isArray(data) && data.length > 0) {
+        logger.info(`SSE: Sent notification to userId: ${userId} (${userClients.length} clients)`);
+      }
     }
   }
 }

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,4 +1,4 @@
-import type { NotificationType } from '@prisma/client';
+import type { Notification, NotificationType } from '@prisma/client';
 import type { Response } from 'express';
 
 import { notificationRepository } from '../repositories/notification.repository.js';
@@ -16,7 +16,7 @@ class NotificationService {
   // 한 유저가 여러 기기에서 접속할 수 있도록, Response 객체를 배열로 관리합니다.
   private clients: Map<string, Response[]> = new Map();
   // 클라이언트별 알림 대기열
-  private notificationsQueue: Map<string, any[]> = new Map();
+  private notificationsQueue: Map<string, Notification[]> = new Map();
   // 동시 접속 허용 수
   private readonly MAX_CONNECTIONS = 3;
 

--- a/test-https/notification.http
+++ b/test-https/notification.http
@@ -1,3 +1,5 @@
+### sse 테스트는 9번 항목에 있습니다. (로그인해서 토큰 받고 실행해주세요)
+
 ### 0. 공통 변수
 @baseUrl = http://localhost:3001
 @productId = testProductId
@@ -32,6 +34,17 @@ Content-Type: application/json
 
 ### 구매자 토큰 저장
 @buyerToken = {{buyerLogin.response.body.accessToken}}
+
+
+# -----------------------------------------------------------------
+# 2.1. 구매자 정보 조회 (ID 획득용)
+# -----------------------------------------------------------------
+# @name getMe
+GET {{baseUrl}}/api/users/me
+Authorization: Bearer {{buyerToken}}
+
+### 구매자 ID 저장
+@buyerId = {{getMe.response.body.id}}
 
 
 # -----------------------------------------------------------------
@@ -105,9 +118,56 @@ Authorization: Bearer {{buyerToken}}
 
 ###
 
+# =================================================================
+# 9. SSE 30초 주기 테스트
+# =================================================================
+
+# 테스트 방법:
+# 1. 아래 "SSE 연결 시작" 요청을 먼저 보냅니다.
+# 2. 곧바로 아래 "테스트 알림 생성 1", "테스트 알림 생성 2" 요청을 빠르게 연속으로 보냅니다.
+# 3. "SSE 연결 시작" 요청의 응답 창을 확인합니다.
+#    - 30초 이내에 2개의 알림 데이터가 배열 형태로 한꺼번에 수신되는지 확인합니다. (예: data: [ {..}, {..} ])
+# 4. 아무 요청도 보내지 않고 30초를 더 기다립니다.
+#    - 빈 배열(heartbeat)이 수신되는지 확인합니다. (예: data: [])
+
 # -----------------------------------------------------------------
-# 9. SSE 연결 테스트 (구매자)
+# 9.1. SSE 연결 시작 (구매자)
 # -----------------------------------------------------------------
+# @name subscribeToSSE
 GET {{baseUrl}}/api/notifications/sse
 Authorization: Bearer {{buyerToken}}
 Accept: text/event-stream
+
+###
+
+# -----------------------------------------------------------------
+# 9.2. 테스트 알림 생성 1 (구매자에게)
+# -----------------------------------------------------------------
+# @name createTestNotification1
+POST {{baseUrl}}/api/notifications
+Authorization: Bearer {{buyerToken}}
+Content-Type: application/json
+
+{
+  "userId": "{{buyerId}}",
+  "type": "INQUIRY_REPLIED_FOR_BUYER",
+  "content": "첫 번째 테스트 알림입니다.",
+  "url": "/test/1"
+}
+
+###
+
+# -----------------------------------------------------------------
+# 9.3. 테스트 알림 생성 2 (구매자에게)
+# -----------------------------------------------------------------
+# @name createTestNotification2
+POST {{baseUrl}}/api/notifications
+Authorization: Bearer {{buyerToken}}
+Content-Type: application/json
+
+{
+  "userId": "{{buyerId}}",
+  "type": "INQUIRY_REPLIED_FOR_BUYER",
+  "content": "두 번째 테스트 알림입니다.",
+  "url": "/test/2"
+}


### PR DESCRIPTION
## 📝 변경 사항 요약 (Summary of Changes)
기존의 알림 즉시 전송 방식을 30초 주기의 배치(Batch) 전송 방식으로 변경했습니다. 이제 서버는 발생한 알림을 즉시 보내지 않고 대기열에 모아두었다가, 30초마다 일괄 전송합니다. 또한, 전송할 알림이 없더라도 주기적으로 빈 배열([])을 보내 연결 상태를 확인하는 기능을 추가했습니다.( 예시 사이트 참고)

## 📚 관련 이슈 (Related Issues)
Closes #102 

## ✨ 핵심 변경 사항 (Core Changes)
1. NotificationService 구조 변경

대기열(Queue) 도입: notificationsQueue (Map<string, Notification[]>)를 추가하여 사용자별로 알림을 임시 저장하도록 했습니다.

스케줄러 추가: 생성자(constructor)에서 setInterval을 사용하여 30초마다 sendBufferedNotifications 메서드가 실행되도록 설정했습니다.

2. 전송 로직 변경

createNotification 시 큐에 push만 수행.

30초마다 도는 스케줄러가 접속 중인 모든 클라이언트를 순회.

대기열에 알림이 있으면: 알림 목록 전송 ([{...}, {...}]).

대기열이 비어 있으면: 빈 배열 전송 ([]) 


## 📸 스크린 샷 (Screen Shots)
SSE 전송 (30초마다 알림이 있으면 전송, 없으면 빈 배열 전송)
<img width="990" height="1193" alt="스크린샷 2025-12-31 191128" src="https://github.com/user-attachments/assets/67987d3b-70b2-4b37-b34f-cb6ad7210653" />

## 🔍 코드 리뷰 시 특별히 더 신경 써줬으면 하는 부분 (Specific areas for review)
notification.service.ts의 sendBufferedNotifications 메서드에서 접속 중인 모든 클라이언트를 순회하며 알림을 보내는 로직이 효율적인지 봐주시면 감사하겠습니다.


✅ 체크리스트 (Checklist)
[x] 빌드 및 테스트를 통과했습니다. (HTTP Request 테스트 완료)

[x] 코드 스타일 가이드라인을 준수했습니다. (ESLint 통과)

[x] 리뷰어에게 필요한 모든 정보를 제공했습니다.